### PR TITLE
[codex] Add SwapKit no-route amount copy

### DIFF
--- a/intl_en_US.arb
+++ b/intl_en_US.arb
@@ -1045,6 +1045,7 @@
   "unableSwitchCurrencyTryAgainLater": "Unable to switch currency, please try again later",
   "unknownAuthenticationError": "Unknown error occurred during authentication: {error}",
   "unsupportedNetwork": "Unsupported network",
+  "swapNoRouteForAmount": "No route is available for this amount. Try a higher amount or a different route.",
   "userCancelledAuthentication": "User cancelled authentication",
   "userChoseFallbackAuthentication": "User chose to use fallback authentication method",
   "userWalletNotRegisteredYet": "The user has not registered a wallet yet.",

--- a/intl_es_ES.arb
+++ b/intl_es_ES.arb
@@ -3565,6 +3565,7 @@
   "unableSwitchCurrencyTryAgainLater": "No se puede cambiar la moneda. Vuelve a intentarlo más tarde.",
   "unknownAuthenticationError": "Se produjo un error desconocido durante la autenticación: {error}",
   "unsupportedNetwork": "Red no compatible",
+  "swapNoRouteForAmount": "No hay una ruta disponible para este importe. Prueba con un importe mayor o una ruta diferente.",
   "userCancelledAuthentication": "Autenticación cancelada por el usuario",
   "userChoseFallbackAuthentication": "El usuario eligió utilizar el método de autenticación alternativo",
   "userWalletNotRegisteredYet": "El usuario aún no ha registrado una billetera.",

--- a/intl_ko_KR.arb
+++ b/intl_ko_KR.arb
@@ -3565,6 +3565,7 @@
   "unableSwitchCurrencyTryAgainLater": "통화를 전환할 수 없습니다. 나중에 다시 시도해 주세요.",
   "unknownAuthenticationError": "인증 중 알 수 없는 오류가 발생했습니다: {error}",
   "unsupportedNetwork": "지원되지 않는 네트워크",
+  "swapNoRouteForAmount": "이 금액으로 사용할 수 있는 경로가 없습니다. 더 큰 금액이나 다른 경로를 시도해 주세요.",
   "userCancelledAuthentication": "사용자가 인증을 취소했습니다.",
   "userChoseFallbackAuthentication": "사용자가 대체 인증 방법을 사용하도록 선택했습니다.",
   "userWalletNotRegisteredYet": "사용자는 아직 지갑을 등록하지 않았습니다.",

--- a/intl_pt_PT.arb
+++ b/intl_pt_PT.arb
@@ -3565,6 +3565,7 @@
   "unableSwitchCurrencyTryAgainLater": "Não foi possível trocar de moeda. Tente novamente mais tarde",
   "unknownAuthenticationError": "Ocorreu um erro desconhecido durante a autenticação: {error}",
   "unsupportedNetwork": "Rede não suportada",
+  "swapNoRouteForAmount": "Não há rota disponível para este valor. Tente um valor maior ou uma rota diferente.",
   "userCancelledAuthentication": "Autenticação cancelada pelo usuário",
   "userChoseFallbackAuthentication": "O usuário optou por usar o método de autenticação substituto",
   "userWalletNotRegisteredYet": "O usuário ainda não registrou uma carteira.",

--- a/intl_ru_RU.arb
+++ b/intl_ru_RU.arb
@@ -3565,6 +3565,7 @@
   "unableSwitchCurrencyTryAgainLater": "Не удалось сменить валюту. Повторите попытку позже.",
   "unknownAuthenticationError": "Во время аутентификации произошла неизвестная ошибка: {error}.",
   "unsupportedNetwork": "Неподдерживаемая сеть",
+  "swapNoRouteForAmount": "Для этой суммы нет доступного маршрута. Попробуйте большую сумму или другой маршрут.",
   "userCancelledAuthentication": "Пользователь отменил аутентификацию",
   "userChoseFallbackAuthentication": "Пользователь решил использовать резервный метод аутентификации.",
   "userWalletNotRegisteredYet": "Пользователь еще не зарегистрировал кошелек.",

--- a/intl_uk_UA.arb
+++ b/intl_uk_UA.arb
@@ -3565,6 +3565,7 @@
   "unableSwitchCurrencyTryAgainLater": "Не вдається змінити валюту, повторіть спробу пізніше",
   "unknownAuthenticationError": "Під час автентифікації сталася невідома помилка: {error}",
   "unsupportedNetwork": "Непідтримувана мережа",
+  "swapNoRouteForAmount": "Для цієї суми немає доступного маршруту. Спробуйте більшу суму або інший маршрут.",
   "userCancelledAuthentication": "Користувач скасував автентифікацію",
   "userChoseFallbackAuthentication": "Користувач вибрав резервний метод автентифікації",
   "userWalletNotRegisteredYet": "Користувач ще не зареєстрував гаманець.",

--- a/intl_vi_VN.arb
+++ b/intl_vi_VN.arb
@@ -3565,6 +3565,7 @@
   "unableSwitchCurrencyTryAgainLater": "Không thể chuyển đổi đơn vị tiền tệ, vui lòng thử lại sau",
   "unknownAuthenticationError": "Đã xảy ra lỗi không xác định trong quá trình xác thực: {error}",
   "unsupportedNetwork": "Mạng không được hỗ trợ",
+  "swapNoRouteForAmount": "Không có tuyến nào khả dụng cho số tiền này. Hãy thử số tiền lớn hơn hoặc tuyến khác.",
   "userCancelledAuthentication": "Người dùng đã hủy xác thực",
   "userChoseFallbackAuthentication": "Người dùng đã chọn sử dụng phương thức xác thực dự phòng",
   "userWalletNotRegisteredYet": "Người dùng chưa đăng ký ví.",

--- a/intl_zh_CN.arb
+++ b/intl_zh_CN.arb
@@ -3565,6 +3565,7 @@
   "unableSwitchCurrencyTryAgainLater": "无法切换货币，请稍后重试",
   "unknownAuthenticationError": "身份验证期间发生未知错误：{error}",
   "unsupportedNetwork": "不支持的网络",
+  "swapNoRouteForAmount": "当前金额没有可用路线。请尝试更高金额或其他路线。",
   "userCancelledAuthentication": "用户取消身份验证",
   "userChoseFallbackAuthentication": "用户选择使用后备身份验证方法",
   "userWalletNotRegisteredYet": "用户尚未注册钱包。",


### PR DESCRIPTION
## Summary
- add localized copy for SwapKit routes that are unavailable at the entered amount
- keep the existing unsupported-network/pair copy separate from amount-size no-route copy

## Validation
- `flutter pub run intl_utils:generate` in `package/doge_assets`
- generated mobile localization files were validated from the mobile app checkout
